### PR TITLE
Fixed pip install to install philo templates

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include MANIFEST.in
+include LICENSE
+recursive-include philo/templates *


### PR DESCRIPTION
It was lacking MANIFEST.in file listing the non Python files to install.
